### PR TITLE
AlToC5.exe to AliasToCatia5.exe

### DIFF
--- a/python/tk_framework_aliastranslations/settings.py
+++ b/python/tk_framework_aliastranslations/settings.py
@@ -22,7 +22,7 @@ class TranslatorSettings(object):
     _EXEC_NAME_LIST = {
         "wref": "AlToRef.exe",
         "igs": "AliasToIges.exe",
-        "catpart": "AlToC5.exe",
+        "catpart": "AliasToCatia5.exe",
         "jt": "AlToJt.bat",
         "stp": "AliasToStep.exe",
     }


### PR DESCRIPTION
AlToC5.exe doesn't exist in bin/translators path