### PR TITLE
SHOT-3356:  Fix translation caused by file I/O permission errors

### DIFF
--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -144,7 +144,7 @@ class Translator(object):
             # run the translation. note that command arguments are not quoted using shlex.quote
             # because the Alias translators do not support quoted arguments and can handle
             # spaces in the file paths
-            logger.info("Running translation command: {}").format(" ".join(cmd))
+            logger.info("Running translation command: {}".format(" ".join(cmd)))
             subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=False)
 
             # copy the translated file from the temp location to the desired destination

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -1,12 +1,13 @@
-# Copyright (c) 2020 Shotgun Software Inc.
+# Copyright (c) 2023 Autodesk
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# This work is provided "AS IS" and subject to the ShotGrid Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
 # By accessing, using, copying or modifying this work you indicate your
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
-# not expressly granted therein are reserved by Shotgun Software Inc.
+# agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Autodesk.
+
 import os
 import sgtk
 import subprocess

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -141,7 +141,9 @@ class Translator(object):
             if self.translator_settings.extra_params:
                 cmd.extend(self.translator_settings.extra_params)
 
-            # run the translation
+            # run the translation. note that command arguments are not quoted using shlex.quote
+            # because the Alias translators do not support quoted arguments and can handle
+            # spaces in the file paths
             logger.info("Running translation command: {}").format(" ".join(cmd))
             subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=False)
 

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -142,6 +142,7 @@ class Translator(object):
                 cmd.extend(self.translator_settings.extra_params)
 
             # run the translation
+            logger.info("Running translation command: {}").format(" ".join(cmd))
             subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=False)
 
             # copy the translated file from the temp location to the desired destination

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -117,14 +117,20 @@ class Translator(object):
             cmd.append("-productKey")
             cmd.append(self.translator_settings.license_settings.get("product_key", ""))
             cmd.append("-productVersion")
-            cmd.append(self.translator_settings.license_settings.get("product_version", ""))
+            cmd.append(
+                self.translator_settings.license_settings.get("product_version", "")
+            )
             cmd.append("-productLicenseType")
             cmd.append(
-                self.translator_settings.license_settings.get("product_license_type", "")
+                self.translator_settings.license_settings.get(
+                    "product_license_type", ""
+                )
             )
             cmd.append("-productLicensePath")
             cmd.append(
-                self.translator_settings.license_settings.get("product_license_path", "")
+                self.translator_settings.license_settings.get(
+                    "product_license_path", ""
+                )
             )
 
             cmd.append("-i")

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Autodesk
+# Copyright (c) 2024 Autodesk
 #
 # CONFIDENTIAL AND PROPRIETARY
 #

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -81,11 +81,7 @@ class Translator(object):
         return True
 
     def execute(self):
-        """
-        Run the translation command in a subprocess and wait for command to complete.
-        """
-
-        current_engine = sgtk.platform.current_engine()
+        """Run the translation command in a subprocess and wait for command to complete."""
 
         if not self.translator_path:
             raise ValueError("Couldn't translate file: missing translator path")
@@ -100,6 +96,7 @@ class Translator(object):
             raise ValueError("Couldn't translate file: it doesn't exist on disk.")
 
         # be sure the destination folder is created
+        current_engine = sgtk.platform.current_engine()
         current_engine.ensure_folder_exists(os.path.dirname(self.output_path))
 
         # build the command line which will be used to do the translation

--- a/python/tk_framework_aliastranslations/translator.py
+++ b/python/tk_framework_aliastranslations/translator.py
@@ -135,8 +135,8 @@ class Translator(object):
             if self.translator_settings.extra_params:
                 cmd.extend(self.translator_settings.extra_params)
 
-            # finally run the translation
-            subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=True)
+            # run the translation
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=False)
 
             # copy the translated file from the temp location to the desired destination
             # before exiting this scope, else the temp directory and file will be deleted


### PR DESCRIPTION
* Perform the translation to a local temp file path and copy the file to the desired location once translation has completed