### PR TITLE
SG-43665 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -23,6 +23,7 @@ description: "A Collection of utilities to simplify Alias file translations."
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.19.1"
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in `info.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)